### PR TITLE
Lower min sdk version on android

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -33,7 +33,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:0.8.2'
+    implementation 'com.mirego.trikot:kword:0.7.2'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
 }
 

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -19,12 +19,12 @@ repositories {
 group 'com.mirego.trikot.kword'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.0"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion 14
+        targetSdkVersion 29
     }
 }
 
@@ -33,7 +33,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:0.2.2'
+    implementation 'com.mirego.trikot:kword:0.8.2'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
 }
 


### PR DESCRIPTION
## Description
No actual code change had to be done.

## Motivation and Context
I needed to have API 19+ in my project. I lowered it even more since there was no reason not to.

## How Has This Been Tested?
Tested it in my project with min sdk api level 19

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
