### PR TITLE
Multi brand features

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -18,6 +18,17 @@ repositories {
 
 group 'com.mirego.trikot.kword'
 
+kotlin {
+    sourceSets {
+        all {
+            languageSettings {
+                useExperimentalAnnotation('kotlinx.serialization.UnstableDefault')
+                useExperimentalAnnotation('kotlinx.serialization.ImplicitReflectionSerializer')
+            }
+        }
+    }
+}
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"

--- a/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
@@ -32,7 +32,7 @@ object AndroidKWord {
                 val fileContent =
                     KWord::class.java.getResource("/translations/translation.$variantPath.json")!!
                         .readText()
-                map.putAll(json.parseMap<String, String>(fileContent))
+                map.putAll(json.parseMap(fileContent))
             } catch (ioException: IOException) {
                 Log.v("Kword", "Unable to load translation $variantPath", ioException)
             }

--- a/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
@@ -7,6 +7,12 @@ import kotlinx.serialization.parseMap
 import java.io.IOException
 
 object AndroidKWord {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        serializeSpecialFloatingPointValues = true
+    }
+
     fun setCurrentLanguageCode(code: String) {
         setCurrentLanguageCodes(KWord, code)
     }
@@ -30,11 +36,5 @@ object AndroidKWord {
             }
         }
         i18N.changeLocaleStrings(map)
-    }
-
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        serializeSpecialFloatingPointValues = true
     }
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.kword.android.ktx
 
+import android.util.Log
 import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.kword.KWord
 import kotlinx.serialization.json.Json
@@ -33,6 +34,7 @@ object AndroidKWord {
                         .readText()
                 map.putAll(json.parseMap<String, String>(fileContent))
             } catch (ioException: IOException) {
+                Log.v("Kword", "Unable to load translation $variantPath", ioException)
             }
         }
         i18N.changeLocaleStrings(map)

--- a/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
@@ -1,19 +1,40 @@
 package com.mirego.trikot.kword.android.ktx
 
-import kotlinx.serialization.ImplicitReflectionSerializer
-import kotlinx.serialization.UnstableDefault
+import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.kword.KWord
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.parseMap
-import com.mirego.trikot.kword.KWord
+import java.io.IOException
 
 object AndroidKWord {
-    @UseExperimental(UnstableDefault::class)
-    @ImplicitReflectionSerializer
     fun setCurrentLanguageCode(code: String) {
-        val fileContent =
-            KWord::class.java.getResource("/translations/translation.$code.json")!!
-                .readText()
-        val json = Json.nonstrict.parseMap<String, String>(fileContent)
-        KWord.changeLocaleStrings(json)
+        setCurrentLanguageCodes(KWord, code)
+    }
+
+    fun setCurrentLanguageCode(i18N: I18N, code: String) {
+        setCurrentLanguageCodes(i18N, code)
+    }
+
+    fun setCurrentLanguageCodes(i18N: I18N, vararg codes: String) {
+        val map = mutableMapOf<String, String>()
+        val variant = mutableListOf<String>()
+        codes.forEach {
+            variant.add(it)
+            val variantPath = variant.joinToString(".")
+            try {
+                val fileContent =
+                    KWord::class.java.getResource("/translations/translation.$variantPath.json")!!
+                        .readText()
+                map.putAll(json.parseMap<String, String>(fileContent))
+            } catch (ioException: IOException) {
+            }
+        }
+        i18N.changeLocaleStrings(map)
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        serializeSpecialFloatingPointValues = true
     }
 }

--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -50,7 +50,7 @@ class KWordEnumGenerate extends DefaultTask {
     }
 
     private List<String> parseKeys() {
-        Set<String> keys = new HashSet<>()
+        final Set<String> keys = new HashSet<>()
         getTranslationFiles().collect {
             Map<String, Object> translations = new JsonSlurper().parse(it) as Map<String, Object>
             keys.addAll(translations.keySet())

--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -11,11 +11,6 @@ class KWordEnumGenerate extends DefaultTask {
     @Lazy
     KWordExtension extension = { project.extensions.getByType(KWordExtension) }()
 
-    File translationFile
-    String enumClassName
-    File generatedDir
-
-
     @TaskAction
     void generate() {
         ClassName generatedClassName = ClassName.bestGuess(getEnumClassName())
@@ -55,23 +50,27 @@ class KWordEnumGenerate extends DefaultTask {
     }
 
     private List<String> parseKeys() {
-        Map<String, Object> translations = new JsonSlurper().parse(getTranslationFile()) as Map<String, Object>
-        translations.keySet().toList()
+        Set<String> keys = new HashSet<>()
+        getTranslationFiles().collect {
+            Map<String, Object> translations = new JsonSlurper().parse(it) as Map<String, Object>
+            keys.addAll(translations.keySet())
+        }
+        keys.toList()
     }
 
     static String underscoreKey(String key) {
         key.replaceAll(/([A-Z])/, '_$1').replaceAll(/\./, '_').toUpperCase()
     }
 
-    File getTranslationFile() {
-        return translationFile ?: extension.translationFile
+    List<File> getTranslationFiles() {
+        return extension.translationFile != null ? Arrays.asList(extension.translationFile) : extension.translationFiles
     }
 
     String getEnumClassName() {
-        return enumClassName ?: extension.enumClassName
+        return extension.enumClassName
     }
 
     File getGeneratedDir() {
-        return generatedDir ?: extension.generatedDir
+        return extension.generatedDir
     }
 }

--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
@@ -6,6 +6,7 @@ class KWordExtension {
     private Project project
 
     File translationFile
+    List<File> translationFiles
     String enumClassName
     File generatedDir
 
@@ -19,6 +20,14 @@ class KWordExtension {
 
     void translationFile(Object translationFile) {
         this.translationFile = project.file(translationFile)
+    }
+
+    List<File> getTranslationFiles() {
+        return translationFiles
+    }
+
+    void translationFiles(Object... translationFiles) {
+        this.translationFiles = project.files(translationFiles).toList()
     }
 
     String getEnumClassName() {

--- a/kword/build.gradle
+++ b/kword/build.gradle
@@ -37,6 +37,8 @@ kotlin {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test-common'
                 implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
+                implementation 'org.jetbrains.kotlin:kotlin-test'
+                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
             }
         }
         jvmMain {

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
@@ -1,0 +1,47 @@
+package com.mirego.trikot.kword
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+
+open class DefaultI18N : I18N {
+    private val sourceRef: AtomicReference<KWordSource> =
+        AtomicReference(MapKeywordSource(HashMap()))
+    private val source: KWordSource
+        get() = sourceRef.value
+    private val translationArgumentsParser: TranslationArgumentsParser =
+        TranslationArgumentsParser()
+
+    override fun changeLocaleStrings(strings: Map<String, String>) {
+        changeLocaleStrings(MapKeywordSource(strings))
+    }
+
+    override fun changeLocaleStrings(source: KWordSource) {
+        sourceRef.compareAndSet(sourceRef.value, source)
+    }
+
+    override operator fun get(key: KWordKey): String {
+        return getWithReplacements(key)
+    }
+
+    override fun t(key: KWordKey): String {
+        return this[key]
+    }
+
+    override fun t(key: KWordKey, count: Int, vararg arguments: String): String {
+        // TODO: implement zero, one, other
+        return t(key)
+    }
+
+    override fun t(key: KWordKey, vararg arguments: Pair<String, String>): String {
+        return getWithReplacements(key, mapOf(*arguments))
+    }
+
+    private fun getWithReplacements(
+        key: KWordKey,
+        arguments: Map<String, String> = emptyMap()
+    ): String {
+        return translationArgumentsParser.replaceInTranslation(
+            source.get(key.translationKey),
+            sourceRef.value.strings + arguments
+        )
+    }
+}

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/I18N.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/I18N.kt
@@ -3,7 +3,7 @@ package com.mirego.trikot.kword
 import kotlin.js.JsName
 
 interface I18N {
-    operator fun get(kKey: KWordKey): String
+    operator fun get(key: KWordKey): String
 
     fun changeLocaleStrings(strings: Map<String, String>)
 

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/KWord.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/KWord.kt
@@ -1,7 +1,6 @@
 package com.mirego.trikot.kword
 
 import kotlin.js.JsName
-import com.mirego.trikot.foundation.concurrent.AtomicReference
 
 interface KWordKey {
     val translationKey: String
@@ -10,43 +9,14 @@ interface KWordKey {
 interface KWordSource {
     @JsName("get")
     fun get(key: String): String
+
+    val strings: Map<String, String>
 }
 
-class MapKeywordSource(private val source: Map<String, String>) : KWordSource {
+class MapKeywordSource(override val strings: Map<String, String>) : KWordSource {
     override operator fun get(key: String): String {
-        return source[key] ?: key
+        return strings[key] ?: key
     }
 }
 
-object KWord : I18N {
-    private val sourceRef: AtomicReference<KWordSource> =
-        AtomicReference(MapKeywordSource(HashMap()))
-    private val source: KWordSource
-        get() = sourceRef.value
-    private val translationArgumentsParser: TranslationArgumentsParser = TranslationArgumentsParser()
-
-    override fun changeLocaleStrings(strings: Map<String, String>) {
-        changeLocaleStrings(MapKeywordSource(strings))
-    }
-
-    override fun changeLocaleStrings(source: KWordSource) {
-        sourceRef.compareAndSet(sourceRef.value, source)
-    }
-
-    override operator fun get(kKey: KWordKey): String {
-        return source.get(kKey.translationKey)
-    }
-
-    override fun t(key: KWordKey): String {
-        return this[key]
-    }
-
-    override fun t(key: KWordKey, count: Int, vararg arguments: String): String {
-        // TODO: implement zero, one, other
-        return t(key)
-    }
-
-    override fun t(key: KWordKey, vararg arguments: Pair<String, String>): String {
-        return translationArgumentsParser.replaceInTranslation(t(key), arguments)
-    }
-}
+object KWord : DefaultI18N()

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
@@ -1,11 +1,11 @@
 package com.mirego.trikot.kword
 
-class TranslationArgumentsParser {
-    fun replaceInTranslation(translation: String, arguments: Array<out Pair<String, String>>): String {
+internal class TranslationArgumentsParser {
+    fun replaceInTranslation(translation: String, arguments: Map<String, String>): String {
         var parsedTranslation: String = translation
 
         for (argument in arguments) {
-            parsedTranslation = parsedTranslation.replace("{{${argument.first}}}", argument.second)
+            parsedTranslation = parsedTranslation.replace("{{${argument.key}}}", argument.value)
         }
 
         return parsedTranslation

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
@@ -1,8 +1,10 @@
 package com.mirego.trikot.kword
 
 internal class TranslationArgumentsParser {
+    private val regex = Regex("\\{\\{([^\\}]+)\\}\\}")
+
     fun replaceInTranslation(translation: String, arguments: Map<String, String>) =
-        translation.replace(Regex("\\{\\{([^}]+)}}")) {
+        translation.replace(regex) {
             arguments[it.groupValues[1]] ?: it.value
         }
 }

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
@@ -1,13 +1,8 @@
 package com.mirego.trikot.kword
 
 internal class TranslationArgumentsParser {
-    fun replaceInTranslation(translation: String, arguments: Map<String, String>): String {
-        var parsedTranslation: String = translation
-
-        for (argument in arguments) {
-            parsedTranslation = parsedTranslation.replace("{{${argument.key}}}", argument.value)
+    fun replaceInTranslation(translation: String, arguments: Map<String, String>) =
+        translation.replace(Regex("\\{\\{([^}]+)}}")) {
+            arguments[it.groupValues[1]] ?: it.value
         }
-
-        return parsedTranslation
-    }
 }

--- a/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
+++ b/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
@@ -35,6 +35,11 @@ class DefaultI18NTests {
     }
 
     @Test
+    fun `given string with missing arguments then it keeps the placeholder`() {
+        assertEquals("Hi my name is {{name}}", defaultI18N.t("hi_my_name_is_key".kk))
+    }
+
+    @Test
     fun `given string with localized replacements and arguments then it uses argument over localized replacement`() {
         assertEquals("this is foo rab", defaultI18N.t("foo_bar_key".kk, "bar_key" to "rab"))
     }

--- a/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
+++ b/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
@@ -1,0 +1,49 @@
+package com.mirego.trikot.kword
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultI18NTests {
+
+    companion object {
+        val STRINGS = mapOf(
+            "foo_key" to "foo",
+            "bar_key" to "bar",
+            "foo_bar_key" to "this is {{foo_key}} {{bar_key}}",
+            "hi_my_name_is_key" to "Hi my name is {{name}}"
+        )
+    }
+
+    private val defaultI18N = DefaultI18N()
+
+    @BeforeTest
+    fun setup() {
+        defaultI18N.changeLocaleStrings(STRINGS)
+    }
+
+    @Test
+    fun `given string with localized replacements then it replace placeholders`() {
+        assertEquals("foo", defaultI18N["foo_key".kk])
+        assertEquals("bar", defaultI18N["bar_key".kk])
+        assertEquals("this is foo bar", defaultI18N["foo_bar_key".kk])
+    }
+
+    @Test
+    fun `given string with arguments`() {
+        assertEquals("Hi my name is Bob", defaultI18N.t("hi_my_name_is_key".kk, "name" to "Bob"))
+    }
+
+    @Test
+    fun `given string with localized replacements and arguments then it uses argument over localized replacement`() {
+        assertEquals("this is foo rab", defaultI18N.t("foo_bar_key".kk, "bar_key" to "rab"))
+    }
+
+    private val String.kk: KWordKey
+        get() {
+            return object : KWordKey {
+                override val translationKey: String
+                    get() = this@kk
+            }
+        }
+}

--- a/swift-extensions/TrikotKword.swift
+++ b/swift-extensions/TrikotKword.swift
@@ -5,14 +5,30 @@ public class TrikotKword: NSObject {
     public static let shared = TrikotKword()
 
     public func setCurrentLanguage(_ languageCode: String) {
-        do {
-            let translationBundle = Bundle(for: KWord.self)
-            let contents = try String(contentsOfFile: translationBundle.path(forResource: "translation.\(languageCode)", ofType: "json") ?? "")
-            let decoder = JSONDecoder()
-            let strings = try decoder.decode([String: String].self, from: contents.data(using: .utf8)!)
-            KWord().changeLocaleStrings(strings: strings)
-        } catch let error {
-            print("Unable to load translation: \(error)")
+        setCurrentLanguage(i18N: KWord(), languageCode: languageCode)
+    }
+
+    public func setCurrentLanguage(i18N: I18N, languageCode: String) {
+        setCurrentLanguage(i18N: i18N, codes: languageCode)
+    }
+
+    public func setCurrentLanguage(i18N: I18N, codes: String...) {
+        var allStrings = [String: String]()
+        var variant = [String]()
+        for code in codes {
+            variant.append(code)
+            let variantPath = variant.joined(separator: ".")
+            do {
+                let translationBundle = Bundle(for: KWord.self)
+                let contents = try String(contentsOfFile: translationBundle.path(forResource: "translation.\(variantPath)", ofType: "json") ?? "")
+                let decoder = JSONDecoder()
+                let strings = try decoder.decode([String: String].self, from: contents.data(using: .utf8)!)
+                allStrings.merge(strings, uniquingKeysWith: { (_, last) in last })
+            } catch let error {
+                print("Unable to load translation: \(error)")
+            }
         }
+        KWord().changeLocaleStrings(strings: allStrings)
     }
 }
+


### PR DESCRIPTION
## Description
- Add support for multiple sources of strings.
 For instance it is now possible to have something like:
```
translations.en.json
translations.en.brand1.json
translations.en.brand2.json
translations.fr.json
translations.fr.brand1.json
translations.fr.brand2.json
```

- Placeholder resolution now lookup into translated string table as well.
 For instance
```
"foo_key": "foo"
"bar_key": "bar"
"foo_bar_key": "this is {{foo_key}} {{bar_key}}"
```

`KWord[FOO_BAR_KEY]` will resolve to "this is foo bar"

- kword now inherit from DefaultI18N where all the logic was moved.

- Improve translation parser, use a regex rather than iterating over all replacements

**_Everything is backward compatible and applications using KWord will have nothing to migrate._**

## Motivation and Context
We needed to have string overrides and string placeholder to support multiple brands in our app without having to duplicate all the strings.

## How Has This Been Tested?
Some unit tests and also in an app with multiple brands.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
