### PR TITLE
Declare input & output on gradle task

### DIFF
--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -3,6 +3,8 @@ package com.mirego.kword
 import com.squareup.kotlinpoet.*
 import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class KWordEnumGenerate extends DefaultTask {
@@ -62,6 +64,7 @@ class KWordEnumGenerate extends DefaultTask {
         key.replaceAll(/([A-Z])/, '_$1').replaceAll(/\./, '_').toUpperCase()
     }
 
+    @InputFiles
     List<File> getTranslationFiles() {
         return extension.translationFile != null ? Arrays.asList(extension.translationFile) : extension.translationFiles
     }
@@ -72,5 +75,10 @@ class KWordEnumGenerate extends DefaultTask {
 
     File getGeneratedDir() {
         return extension.generatedDir
+    }
+
+    @OutputFile
+    File getGeneratedClassFile() {
+        new File(getGeneratedDir(), getEnumClassName().replaceAll(/\./, '/') + '.kt')
     }
 }


### PR DESCRIPTION
Android Studio kindly pointed out that kwordGenerateEnum task must run every time as there is no declared output.

## Description
Expose inputs and output through annotation in task class.

## How Has This Been Tested?
Manually validated in trikot.patron. 
Task is skipped (UP-TO_DATE) on second run.
Task run on change to translation json file.
Task run when deleting generated kt class.
