### PR TITLE
Update to Kotlin 1.4 and bump version number to 1.0.0

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -10,6 +10,7 @@ plugins {
 repositories {
     google()
     jcenter()
+    mavenLocal()
     mavenCentral()
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
@@ -17,17 +18,6 @@ repositories {
 }
 
 group 'com.mirego.trikot.kword'
-
-kotlin {
-    sourceSets {
-        all {
-            languageSettings {
-                useExperimentalAnnotation('kotlinx.serialization.UnstableDefault')
-                useExperimentalAnnotation('kotlinx.serialization.ImplicitReflectionSerializer')
-            }
-        }
-    }
-}
 
 android {
     compileSdkVersion 29
@@ -43,8 +33,8 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:1.0.0-SNAPSHOT'
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
+    implementation 'com.mirego.trikot:kword:1.0.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinx_serialization_version"
 }
 
 release {

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -45,7 +45,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:0.11.2-1.4-M3'
+    implementation 'com.mirego.trikot:kword:0.10.1-1.4-M3'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
 }
 

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -11,7 +11,6 @@ repositories {
     google()
     jcenter()
     mavenCentral()
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
@@ -32,7 +31,6 @@ kotlin {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -45,14 +43,14 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:0.10.1-1.4-M3'
+    implementation 'com.mirego.trikot:kword:1.0.0-SNAPSHOT'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
 }
 
 release {
     checkTasks = ['check']
     buildTasks = ['publish']
-    updateVersionPart = 1
+    updateVersionPart = 2
     tagPrefix = 'android-ktx-'
 }
 

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -11,6 +11,7 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
@@ -44,7 +45,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.mirego.trikot:kword:0.10.1'
+    implementation 'com.mirego.trikot:kword:0.11.2-1.4-M3'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinx_serialization_version"
 }
 

--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:32:43 EDT 2020
-version=0.8.1-1.4-M3
+version=1.0.0-SNAPSHOT

--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:32:43 EDT 2020
-version=0.8.2-1.4-M3
+version=0.8.1-1.4-M3

--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:32:43 EDT 2020
-version=0.8.1-SNAPSHOT
+version=0.8.2-1.4-M3

--- a/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/kword/android/ktx/AndroidKWord.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.kword.android.ktx
 import android.util.Log
 import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.kword.KWord
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.parseMap
 import java.io.IOException
@@ -11,7 +12,7 @@ object AndroidKWord {
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
-        serializeSpecialFloatingPointValues = true
+        allowSpecialFloatingPointValues = true
     }
 
     fun setCurrentLanguageCode(code: String) {
@@ -32,7 +33,7 @@ object AndroidKWord {
                 val fileContent =
                     KWord::class.java.getResource("/translations/translation.$variantPath.json")!!
                         .readText()
-                map.putAll(json.parseMap(fileContent))
+                map.putAll(json.decodeFromString<Map<String, String>>(fileContent))
             } catch (ioException: IOException) {
                 Log.v("Kword", "Unable to load translation $variantPath", ioException)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
@@ -23,7 +22,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://kotlin.bintray.com/kotlinx" }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
@@ -22,6 +23,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://kotlin.bintray.com/kotlinx" }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
-kotlin_version=1.4-M3
-kotlinx_serialization_version=0.20.0-1.4-M3
-trikot_foundation_version=0.30.1-1.4-M3
+kotlin_version=1.4.0
+kotlinx_serialization_version=1.0.0-SNAPSHOT
+trikot_foundation_version=1.0.0-SNAPSHOT
 kapt.incremental.apt=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.4.0
-kotlinx_serialization_version=1.0.0-SNAPSHOT
-trikot_foundation_version=1.0.0-SNAPSHOT
+kotlinx_serialization_version=1.0.0-RC
+trikot_foundation_version=1.0.0
 kapt.incremental.apt=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 kotlin.code.style=official
 kotlin_version=1.4.0
 kotlinx_serialization_version=1.0.0-RC
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false
 trikot_foundation_version=1.0.0
 kapt.incremental.apt=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.4-M3
 kotlinx_serialization_version=0.20.0-1.4-M3
-trikot_foundation_version=0.30.1
+trikot_foundation_version=0.31.2-1.4-M3
 kapt.incremental.apt=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
-kotlin_version=1.3.70
-kotlinx_serialization_version=0.20.0
+kotlin_version=1.4-M3
+kotlinx_serialization_version=0.20.0-1.4-M3
 trikot_foundation_version=0.30.1
 kapt.incremental.apt=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.4-M3
 kotlinx_serialization_version=0.20.0-1.4-M3
-trikot_foundation_version=0.31.2-1.4-M3
+trikot_foundation_version=0.30.1-1.4-M3
 kapt.incremental.apt=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/kword-plugin/gradle.properties
+++ b/kword-plugin/gradle.properties
@@ -1,3 +1,3 @@
 #Thu Jun 18 07:31:28 EDT 2020
-version=0.6-SNAPSHOT
+version=1.0.0-SNAPSHOT
 group=mirego

--- a/kword/build.gradle
+++ b/kword/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'kotlin-multiplatform'
     id 'com.android.library'
+    id 'kotlin-multiplatform'
     id 'org.jlleitschuh.gradle.ktlint'
     id 'mirego.release' version '1.13'
     id 'mirego.publish' version '1.0'
@@ -8,7 +8,6 @@ plugins {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -20,7 +19,7 @@ repositories {
     google()
     jcenter()
     mavenCentral()
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
+    mavenLocal()
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
@@ -32,23 +31,22 @@ kotlin {
     android {
         publishAllLibraryVariants()
     }
-    targets {
-        fromPreset(presets.jvm, 'jvm')
-        fromPreset(presets.js, 'js')
-        fromPreset(presets.android, 'android')
-        fromPreset(presets.iosArm32, 'iosArm32')
-        fromPreset(presets.iosArm64, 'iosArm64')
-        fromPreset(presets.iosX64, 'iosX64')
-        fromPreset(presets.tvosArm64, 'tvosArm64')
-        fromPreset(presets.tvosX64, 'tvosX64')
+    jvm()
+    ios()
+    iosArm32('iosArm32')
+    tvos()
+    js {
+        browser()
+        nodejs()
     }
+
     sourceSets {
         commonMain {
             dependencies {
                 implementation "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
             }
         }
+
         commonTest {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test-common'
@@ -57,62 +55,48 @@ kotlin {
                 implementation 'org.jetbrains.kotlin:kotlin-test-junit'
             }
         }
+
         jvmMain {
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-jvm:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
+
         jsMain {
+            dependsOn commonMain
+        }
+
+        jsTest {
+            dependsOn commonTest
             dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-js:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
+                implementation 'org.jetbrains.kotlin:kotlin-test-js'
             }
         }
 
         androidMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
 
         nativeMain {
-            dependsOn(commonMain)
+            dependsOn commonMain
         }
 
         iosArm32Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-iosarm32:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         iosArm64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-iosarm64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         iosX64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-iosx64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         tvosArm64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-tvosarm64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         tvosX64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:trikotFoundation-tvosx64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
     }
 }
@@ -120,10 +104,5 @@ kotlin {
 release {
    checkTasks = ['check']
    buildTasks = ['publish']
-   updateVersionPart = 1
-}
-
-// workaround for https://youtrack.jetbrains.com/issue/KT-27170
-configurations {
-    compileClasspath
+   updateVersionPart = 2
 }

--- a/kword/build.gradle
+++ b/kword/build.gradle
@@ -20,6 +20,7 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }

--- a/kword/gradle.properties
+++ b/kword/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:30:58 EDT 2020
-version=0.11.2-1.4-M3
+version=0.10.1-1.4-M3

--- a/kword/gradle.properties
+++ b/kword/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:30:58 EDT 2020
-version=0.10.1-1.4-M3
+version=1.0.0-SNAPSHOT

--- a/kword/gradle.properties
+++ b/kword/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 18 21:30:58 EDT 2020
-version=0.11.1-SNAPSHOT
+version=0.11.2-1.4-M3

--- a/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
+++ b/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
@@ -23,24 +23,24 @@ class DefaultI18NTests {
     }
 
     @Test
-    fun `given string with localized replacements then it replace placeholders`() {
+    fun givenStringWithLocalizedReplacementsThenItReplacePlaceholders() {
         assertEquals("foo", defaultI18N["foo_key".kk])
         assertEquals("bar", defaultI18N["bar_key".kk])
         assertEquals("this is foo bar", defaultI18N["foo_bar_key".kk])
     }
 
     @Test
-    fun `given string with arguments`() {
+    fun givenStringWithArguments() {
         assertEquals("Hi my name is Bob", defaultI18N.t("hi_my_name_is_key".kk, "name" to "Bob"))
     }
 
     @Test
-    fun `given string with missing arguments then it keeps the placeholder`() {
+    fun givenStringWithMissingArgumentsThenItKeepsThePlaceholder() {
         assertEquals("Hi my name is {{name}}", defaultI18N.t("hi_my_name_is_key".kk))
     }
 
     @Test
-    fun `given string with localized replacements and arguments then it uses argument over localized replacement`() {
+    fun givenStringWithLocalizedReplacementsAndArgumentsThenItUsesArgumentOverLocalizedReplacement() {
         assertEquals("this is foo rab", defaultI18N.t("foo_bar_key".kk, "bar_key" to "rab"))
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,5 @@ pluginManagement {
     }
 }
 rootProject.name = 'trikot.kword'
-enableFeaturePreview("GRADLE_METADATA")
 
 include 'kword-plugin', 'kword', 'android-ktx'


### PR DESCRIPTION
## Description
- Update Kotlin compiler to `1.4.0`
- Remove `GRADLE_METADATA` flag as module metadata is used in dependency resolution and included in publications by default in Gradle 6.0 and above
- Remove manual `stdlib` dependencies as they are now included by default
- Migrate to hierarchical project structure and use platform shortcuts.
- Bump version number to `1.0.0` and migrate to semantic versioning

## Motivation and Context
As Kotlin 1.4 has been officially released in the stable channel, it is time to update.

## How Has This Been Tested?
Tests in place still pass, to be tested integrated into an existing project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Every project using trikot.kword will need to update their own version of Kotlin to get the latest updates.