### PR TITLE
Add JS support of KWord translation files

### DIFF
--- a/kword/build.gradle.kts
+++ b/kword/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
     google()
     mavenLocal()
     mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers")
     maven("https://kotlin.bintray.com/kotlinx")
     maven("https://jitpack.io")
     maven("https://plugins.gradle.org/m2/")
@@ -57,6 +58,10 @@ kotlin {
 
         val jsMain by getting {
             dependsOn(commonMain)
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib-js")
+                implementation("org.jetbrains:kotlin-extensions:1.0.1-pre.150-kotlin-1.4.31")
+            }
         }
 
         val jsTest by getting {

--- a/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
+++ b/kword/src/commonTest/kotlin/com/mirego/trikot/kword/DefaultI18NTests.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.kword
 
+import com.mirego.trikot.kword.extensions.toKWordKey
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,31 +25,23 @@ class DefaultI18NTests {
 
     @Test
     fun givenStringWithLocalizedReplacementsThenItReplacePlaceholders() {
-        assertEquals("foo", defaultI18N["foo_key".kk])
-        assertEquals("bar", defaultI18N["bar_key".kk])
-        assertEquals("this is foo bar", defaultI18N["foo_bar_key".kk])
+        assertEquals("foo", defaultI18N["foo_key".toKWordKey])
+        assertEquals("bar", defaultI18N["bar_key".toKWordKey])
+        assertEquals("this is foo bar", defaultI18N["foo_bar_key".toKWordKey])
     }
 
     @Test
     fun givenStringWithArguments() {
-        assertEquals("Hi my name is Bob", defaultI18N.t("hi_my_name_is_key".kk, "name" to "Bob"))
+        assertEquals("Hi my name is Bob", defaultI18N.t("hi_my_name_is_key".toKWordKey, "name" to "Bob"))
     }
 
     @Test
     fun givenStringWithMissingArgumentsThenItKeepsThePlaceholder() {
-        assertEquals("Hi my name is {{name}}", defaultI18N.t("hi_my_name_is_key".kk))
+        assertEquals("Hi my name is {{name}}", defaultI18N.t("hi_my_name_is_key".toKWordKey))
     }
 
     @Test
     fun givenStringWithLocalizedReplacementsAndArgumentsThenItUsesArgumentOverLocalizedReplacement() {
-        assertEquals("this is foo rab", defaultI18N.t("foo_bar_key".kk, "bar_key" to "rab"))
+        assertEquals("this is foo rab", defaultI18N.t("foo_bar_key".toKWordKey, "bar_key" to "rab"))
     }
-
-    private val String.kk: KWordKey
-        get() {
-            return object : KWordKey {
-                override val translationKey: String
-                    get() = this@kk
-            }
-        }
 }

--- a/kword/src/commonTest/kotlin/com/mirego/trikot/kword/extensions/StringToKWordKeyExt.kt.kt
+++ b/kword/src/commonTest/kotlin/com/mirego/trikot/kword/extensions/StringToKWordKeyExt.kt.kt
@@ -1,0 +1,8 @@
+package com.mirego.trikot.kword.extensions
+
+import com.mirego.trikot.kword.KWordKey
+
+data class MockKWordKey(override val translationKey: String) : KWordKey
+
+val String.toKWordKey: KWordKey
+    get() = MockKWordKey(this)

--- a/kword/src/jsMain/kotlin/com.mirego.trikot.kword.js/JsKWord.kt
+++ b/kword/src/jsMain/kotlin/com.mirego.trikot.kword.js/JsKWord.kt
@@ -1,0 +1,39 @@
+package com.mirego.trikot.kword.js
+
+import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.kword.KWord
+import kotlinext.js.require
+
+object JsKWord {
+    fun setCurrentLanguageCode(code: String) {
+        setCurrentLanguageCodes(KWord, code)
+    }
+
+    fun setCurrentLanguageCode(i18N: I18N, code: String) {
+        setCurrentLanguageCodes(i18N, code)
+    }
+
+    fun setCurrentLanguageCodes(i18N: I18N, vararg codes: String) {
+        val map = mutableMapOf<String, String>()
+        val variant = mutableListOf<String>()
+        codes.forEach {
+            variant.add(it)
+            val variantPath = variant.joinToString(".")
+            try {
+                val translations = require("./translations/translation.$variantPath.json")
+                map.putAll(mapOf(translations))
+            } catch (error: dynamic) {
+                println("Unable to parse JSON: $error")
+            }
+        }
+        i18N.changeLocaleStrings(map)
+    }
+
+    private fun mapOf(jsObject: dynamic): Map<String, String> =
+        entriesOf(jsObject).toMap()
+
+    private fun entriesOf(jsObject: dynamic): List<Pair<String, String>> =
+        (js("Object.entries") as (dynamic) -> Array<Array<String>>)
+            .invoke(jsObject)
+            .map { entry -> entry[0] to entry[1] }
+}

--- a/kword/src/jsTest/kotlin/JsKWordTest.kt
+++ b/kword/src/jsTest/kotlin/JsKWordTest.kt
@@ -1,0 +1,39 @@
+import com.mirego.trikot.kword.KWord
+import com.mirego.trikot.kword.extensions.toKWordKey
+import com.mirego.trikot.kword.js.JsKWord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JsKWordTest {
+    @Test
+    fun givenAnExistingKeyThenItReturnsTheTranslation() {
+        JsKWord.setCurrentLanguageCode("en")
+
+        assertEquals("a value", KWord["existing_key".toKWordKey])
+    }
+
+    @Test
+    fun givenALanguageVariantThenItReturnsTheTranslation() {
+        JsKWord.setCurrentLanguageCodes(KWord, "en", "variant")
+
+        assertEquals("variant value!", KWord["existing_key".toKWordKey])
+    }
+
+    @Test
+    fun givenAMissingKeyThenItReturnsTheKeyName() {
+        JsKWord.setCurrentLanguageCode("en")
+
+        val kWordKey = "missing_key"
+
+        assertEquals(kWordKey, KWord[kWordKey.toKWordKey])
+    }
+
+    @Test
+    fun givenALanguageWithoutTranslationFileThenItReturnsTheKeyName() {
+        JsKWord.setCurrentLanguageCode("fr")
+
+        val kWordKey = "existing_key"
+
+        assertEquals(kWordKey, KWord[kWordKey.toKWordKey])
+    }
+}

--- a/kword/src/jsTest/resources/translations/translation.en.json
+++ b/kword/src/jsTest/resources/translations/translation.en.json
@@ -1,0 +1,3 @@
+{
+    "existing_key": "a value"
+}

--- a/kword/src/jsTest/resources/translations/translation.en.variant.json
+++ b/kword/src/jsTest/resources/translations/translation.en.variant.json
@@ -1,0 +1,3 @@
+{
+    "existing_key": "variant value!"
+}


### PR DESCRIPTION
## Description

Implement the support of Javascript for KWord!

## Motivation and Context

Our KMP project was using KWord, and the portion of our Web demo application using translations from KWord was not working. It was due to the fact that we were never setting the `currentLanguageCode()` that has the responsibility of loading the translation file and feeding the expected keys.

Therefore, now, a Web application using KWord can now call `JsKWord.setCurrentLanguageCode("en")` and all translations will then work as expected.

## How Has This Been Tested?

Added a basic coverage of the class `JsKWord` that loads a test translation file and validate that a known key returns the translation as well as a missing key returns the key name.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
