### PR TITLE
Don’t do the regex parsing when there is no arguments to optimize the performance

### DIFF
--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
@@ -46,9 +46,11 @@ open class DefaultI18N : I18N {
     ): String {
         return translationArgumentsParser.replaceInTranslation(
             source.get(key.translationKey),
-            sourceRef.value.strings + arguments
+            arguments,
+            source.strings
         )
     }
+
     companion object {
         private const val COUNT_ARGUMENT = "count"
     }

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/TranslationArgumentsParser.kt
@@ -1,10 +1,12 @@
 package com.mirego.trikot.kword
 
 internal class TranslationArgumentsParser {
-    private val regex = Regex("\\{\\{([^\\}]+)\\}\\}")
+    companion object {
+        private val regex = Regex("\\{\\{([^\\}]+)\\}\\}")
+    }
 
-    fun replaceInTranslation(translation: String, arguments: Map<String, String>) =
+    fun replaceInTranslation(translation: String, arguments: Map<String, String>, secondaryArguments: Map<String, String>? = null) =
         translation.replace(regex) {
-            arguments[it.groupValues[1]] ?: it.value
+            arguments[it.groupValues[1]] ?: secondaryArguments?.get(it.groupValues[1]) ?: it.value
         }
 }


### PR DESCRIPTION
## Description
To optimize performance of the DefaultI18N implementation, I have remove the copy of the map of all the strings when parsing the parameters.

## Motivation and Context
I had performance issue in my application when I was getting too much strings.

## How Has This Been Tested?
Tested in my application

## Types of changes
- [X] Performance improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
