### PR TITLE
Update Kotlin to version 1.5.10 and add watchOS and macOS targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0
+> 2021-06-08
+
+- Added watchOS and macOS targets
+- Updated Kotlin version to 1.5.10
+
 ## 2.1.0
 > 2021-05-10
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.2")
+        classpath("com.android.tools.build:gradle:4.1.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${project.extra["kotlin_version"]}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${project.extra["kotlin_version"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:10.0.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 kotlin.code.style=official
-kotlin_version=1.5.0
-kotlinx_serialization_version=1.0.1
+kotlin_version=1.5.10
+kotlinx_serialization_version=1.2.1
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=2.1.0
+trikot_foundation_version=2.2.1
 kapt.incremental.apt=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/kword-plugin/build.gradle.kts
+++ b/kword-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(localGroovy())
-    implementation("com.squareup:kotlinpoet:1.2.0")
+    implementation("com.squareup:kotlinpoet:1.6.0")
 }
 
 tasks {

--- a/kword-plugin/gradle.properties
+++ b/kword-plugin/gradle.properties
@@ -1,3 +1,3 @@
 #Thu Apr 08 15:58:00 EDT 2021
-version=2.0.2-SNAPSHOT
+version=2.2.0-SNAPSHOT
 group=mirego

--- a/kword/build.gradle.kts
+++ b/kword/build.gradle.kts
@@ -27,6 +27,8 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
+    watchos()
+    macosX64()
     js(IR) {
         browser()
     }
@@ -106,6 +108,22 @@ kotlin {
         }
 
         val tvosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchos32Main by creating {
+            dependsOn(nativeMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val macosX64Main by getting {
             dependsOn(nativeMain)
         }
     }

--- a/kword/gradle.properties
+++ b/kword/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 10 16:20:56 EDT 2021
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT


### PR DESCRIPTION
## 📖 Description
- Added watchOS and macOS targets
- Updated Kotlin version to 1.5.10

## 💭 Motivation and Context
macOS target was needed for a project

## 🧪 How Has This Been Tested?
`./gradlew build`

## 🦀 Dispatch
`#dispatch/kmp`