### PR TITLE
Fix JSExport translation function name for IR compiler

### DIFF
--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/DefaultI18N.kt
@@ -19,11 +19,11 @@ open class DefaultI18N : I18N {
     }
 
     override operator fun get(key: KWordKey): String {
-        return getWithReplacements(key)
+        return t(key)
     }
 
     override fun t(key: KWordKey): String {
-        return this[key]
+        return getWithReplacements(key)
     }
 
     override fun t(key: KWordKey, count: Int, vararg arguments: Pair<String, String>): String {

--- a/kword/src/commonMain/kotlin/com/mirego/trikot/kword/I18N.kt
+++ b/kword/src/commonMain/kotlin/com/mirego/trikot/kword/I18N.kt
@@ -10,6 +10,7 @@ interface I18N {
     @JsName("changeLocaleStringsFromSource")
     fun changeLocaleStrings(source: KWordSource)
 
+    @JsName("t")
     fun t(key: KWordKey): String
 
     @JsName("tc")


### PR DESCRIPTION
## Description
Add a `@JSName` annotation for `I18N.t(key: KWordKey)` to prevent the compiler from generating an alternate name to disambiguate with other `t` functions when using the new IR compiler.

## Motivation and Context
Make it work in JS using IR compiler

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
