### PR TITLE
Support incremental builds

### DIFF
--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -3,7 +3,9 @@ package com.mirego.kword
 import com.squareup.kotlinpoet.*
 import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class KWordEnumGenerate extends DefaultTask {
@@ -63,7 +65,7 @@ class KWordEnumGenerate extends DefaultTask {
         key.replaceAll(/([A-Z])/, '_$1').replaceAll(/\./, '_').toUpperCase()
     }
 
-    @Internal
+    @InputFiles
     List<File> getTranslationFiles() {
         return extension.translationFile != null ? Arrays.asList(extension.translationFile) : extension.translationFiles
     }
@@ -78,8 +80,8 @@ class KWordEnumGenerate extends DefaultTask {
         return extension.generatedDir
     }
 
-    @Internal
+    @OutputFile
     File getGeneratedClassFile() {
-        new File(getGeneratedDir(), getEnumClassName().replaceAll(/\./, '/') + '.kt')
+        return project.file(new File(getGeneratedDir(), getEnumClassName().replaceAll(/\./, '/') + '.kt'))
     }
 }

--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -82,6 +82,6 @@ class KWordEnumGenerate extends DefaultTask {
 
     @OutputFile
     File getGeneratedClassFile() {
-        return project.file(new File(getGeneratedDir(), getEnumClassName().replaceAll(/\./, '/') + '.kt'))
+        return new File(getGeneratedDir(), getEnumClassName().replaceAll(/\./, '/') + '.kt')
     }
 }

--- a/kword/build.gradle.kts
+++ b/kword/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
     }
     jvm()
     ios()
-    iosArm32("iosArm32")
+    iosArm32()
     tvos()
     watchos()
     macosX64()


### PR DESCRIPTION
## Description
Declare output and input files in kword task.
That's required to support incremental builds and skipping the task if it is up-to-date.

Otherwise, the task ran every time.

## Motivation and Context
This reduces incremental build times.

## How Has This Been Tested?
Tested locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
