### PR TITLE
Remove repeat function to be compatible with java 8

### DIFF
--- a/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -47,7 +47,7 @@ class KWordEnumGenerate extends DefaultTask {
 
     private writeFile(ClassName generatedClassName, TypeSpec.Builder enumBuilder) {
         FileSpec.builder(generatedClassName.packageName, generatedClassName.simpleName)
-            .indent(" ".repeat(4))
+            .indent("    ")
             .addType(enumBuilder.build())
             .build()
             .writeTo(getGeneratedDir())


### PR DESCRIPTION
## Description

To be compatible with Java 8, the `repeat` function has been removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)